### PR TITLE
[ UP-3357 ] Handle empty status code for HTTP Check

### DIFF
--- a/pkg/upapi/ep_checks.go
+++ b/pkg/upapi/ep_checks.go
@@ -544,7 +544,7 @@ type CheckHTTP struct {
 	Username               string          `json:"msp_username,omitempty"`
 	Password               string          `json:"msp_password,omitempty"`
 	Proxy                  string          `json:"msp_proxy,omitempty"`
-	StatusCode             string          `json:"msp_status_code,omitempty"`
+	StatusCode             string          `json:"msp_status_code"`
 	SendString             string          `json:"msp_send_string,omitempty"`
 	ExpectString           string          `json:"msp_expect_string,omitempty"`
 	ExpectStringType       string          `json:"msp_expect_string_type,omitempty"`


### PR DESCRIPTION
Always send a status code for an HTTP check, even if it is empty. This is because it is a special case for the API,
which uses special logic to follow redirects until the last call returns a 200 status code.

https://uptimedotcom.atlassian.net/browse/UP-3357