### PR TITLE
feat(SYS-31): add SLA Pages API

### DIFF
--- a/internal/upctl/cli_slareports.go
+++ b/internal/upctl/cli_slareports.go
@@ -1,0 +1,133 @@
+package upctl
+
+import (
+	"context"
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"github.com/uptime-com/uptime-client-go/v2/pkg/upapi"
+)
+
+var slaReportsCmd = &cobra.Command{
+	Use:     "slareports",
+	Aliases: []string{"slareports"},
+	Short:   "Manage SLA reports",
+	Args:    cobra.NoArgs,
+}
+
+func init() {
+	cmd.AddCommand(slaReportsCmd)
+}
+
+var (
+	slaReportsListFlags = upapi.SLAReportListOptions{
+		Page:     1,
+		PageSize: 100,
+		Ordering: "pk",
+	}
+	slaReportsListCmd = &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List slaReports",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return output(slaReportsList(cmd.Context()))
+		},
+	}
+)
+
+func init() {
+	err := Bind(slaReportsListCmd.Flags(), &slaReportsListFlags)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	slaReportsCmd.AddCommand(slaReportsListCmd)
+}
+
+func slaReportsList(ctx context.Context) ([]upapi.SLAReport, error) {
+	return api.SLAReports().List(ctx, upapi.SLAReportListOptions{
+		PageSize: 100,
+		Page:     slaReportsListFlags.Page,
+	})
+}
+
+var (
+	slaReportsCreateFlags = upapi.SLAReport{}
+	slaReportsCreateCmd   = &cobra.Command{
+		Use:     "create",
+		Aliases: []string{"new"},
+		Short:   "Create a new SLA report",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return output(slaReportsCreate(cmd.Context()))
+		},
+	}
+)
+
+func init() {
+	err := Bind(slaReportsCreateCmd.Flags(), &slaReportsCreateFlags)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	slaReportsCmd.AddCommand(slaReportsCreateCmd)
+}
+
+func slaReportsCreate(ctx context.Context) (*upapi.SLAReport, error) {
+	return api.SLAReports().Create(ctx, slaReportsCreateFlags)
+}
+
+var (
+	slaReportsUpdateFlags upapi.SLAReport
+	slaReportsUpdateCmd   = &cobra.Command{
+		Use:     "update <pk>",
+		Aliases: []string{"up"},
+		Short:   "Update a SLA report",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return output(slaReportsUpdate(cmd.Context(), args[0]))
+		},
+	}
+)
+
+func init() {
+	err := Bind(slaReportsUpdateCmd.Flags(), &slaReportsUpdateFlags)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	slaReportsCmd.AddCommand(slaReportsUpdateCmd)
+}
+
+func slaReportsUpdate(ctx context.Context, pkstr string) (*upapi.SLAReport, error) {
+	pk, err := parsePK(pkstr)
+	if err != nil {
+		return nil, err
+	}
+	return api.SLAReports().Update(ctx, upapi.PrimaryKey(pk), slaReportsUpdateFlags)
+}
+
+var slaReportsDeleteCmd = &cobra.Command{
+	Use:     "delete <pk>",
+	Aliases: []string{"del", "rm", "remove"},
+	Short:   "Delete a SLA report",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return output(slaReportsDelete(cmd.Context(), args[0]))
+	},
+}
+
+func init() {
+	slaReportsCmd.AddCommand(slaReportsDeleteCmd)
+}
+
+func slaReportsDelete(ctx context.Context, pkstr string) (*upapi.SLAReport, error) {
+	pk, err := parsePK(pkstr)
+	if err != nil {
+		return nil, err
+	}
+	obj, err := api.SLAReports().Get(ctx, upapi.PrimaryKey(pk))
+	if err != nil {
+		return nil, err
+	}
+	return obj, api.SLAReports().Delete(ctx, upapi.PrimaryKey(pk))
+}

--- a/pkg/upapi/api.go
+++ b/pkg/upapi/api.go
@@ -21,6 +21,7 @@ type API interface {
 	Outages() OutagesEndpoint
 	ProbeServers() ProbeServersEndpoint
 	StatusPages() StatusPagesEndpoint
+	SLAReports() SLAReportsEndpoint
 }
 
 // New returns a new API client instance.
@@ -45,6 +46,9 @@ func New(opts ...Option) (api API, err error) {
 	}
 
 	rq, err := cbd.BuildRequest(context.Background(), "GET", "/", nil, nil)
+	if err != nil {
+		return nil, err
+	}
 	if rq.URL.Host == "" {
 		defs = append(defs, WithBaseURL(defaultBaseURL))
 	}
@@ -66,6 +70,7 @@ func New(opts ...Option) (api API, err error) {
 		outages:      NewOutagesEndpoint(cbd),
 		probeServers: NewProbeServersEndpoint(cbd),
 		statusPages:  NewStatusPagesEndpoint(cbd),
+		slaReports:   NewSLAReportsEndpoint(cbd),
 	}
 	return api, nil
 }
@@ -80,6 +85,7 @@ type apiImpl struct {
 	outages      OutagesEndpoint
 	probeServers ProbeServersEndpoint
 	statusPages  StatusPagesEndpoint
+	slaReports   SLAReportsEndpoint
 }
 
 func (api *apiImpl) Checks() ChecksEndpoint {
@@ -112,4 +118,8 @@ func (api *apiImpl) ProbeServers() ProbeServersEndpoint {
 
 func (api *apiImpl) StatusPages() StatusPagesEndpoint {
 	return api.statusPages
+}
+
+func (api *apiImpl) SLAReports() SLAReportsEndpoint {
+	return api.slaReports
 }

--- a/pkg/upapi/ep_slareport.go
+++ b/pkg/upapi/ep_slareport.go
@@ -1,0 +1,132 @@
+package upapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+type SLAReportService struct {
+	PK   int    `json:"pk,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+//
+// This is workaround for the fact that the API can return either a string (name) or an int for the PK field.
+func (s *SLAReportService) UnmarshalJSON(data []byte) (err error) {
+	if len(data) == 0 {
+		return fmt.Errorf("empty data")
+	}
+
+	if data[0] == '"' {
+		err = json.Unmarshal(data, &s.Name)
+	} else {
+		err = json.Unmarshal(data, &s.PK)
+	}
+
+	return
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+//
+// This is workaround for the fact that the API can accept either a string (name) or an int for the PK field.
+func (s SLAReportService) MarshalJSON() ([]byte, error) {
+	if s.Name != "" && s.PK != 0 {
+		return nil, fmt.Errorf("SLA service can only have a name or a PK, not both")
+	}
+
+	if s.PK != 0 {
+		return json.Marshal(s.PK)
+	}
+
+	return json.Marshal(s.Name)
+}
+
+type SLAReportReportingGroup struct {
+	ID            int      `json:"id,omitempty"`
+	Name          string   `json:"name,omitempty"`
+	GroupServices []string `json:"group_services,omitempty"`
+}
+
+type SLAReport struct {
+	PK                              int64                      `json:"pk,omitempty"`
+	URL                             string                     `json:"url,omitempty"`
+	StatsURL                        string                     `json:"stats_url,omitempty"`
+	Name                            string                     `json:"name"`
+	ServicesTags                    []string                   `json:"service_tags,omitempty"`
+	ServicesSelected                *[]SLAReportService        `json:"services_selected,omitempty"`
+	ReportingGroups                 *[]SLAReportReportingGroup `json:"reporting_groups,omitempty"`
+	DefaultDateRange                string                     `json:"default_date_range,omitempty"`
+	FilterWithDowntime              bool                       `json:"filter_with_downtime,omitempty"`
+	FilterUptimeSLAViolations       bool                       `json:"filter_uptime_sla_violations,omitempty"`
+	FilterSlowest                   bool                       `json:"filter_slowest,omitempty"`
+	FilterResponseTimeSLAViolations bool                       `json:"filter_response_time_sla_violations,omitempty"`
+	ShowUptimeSection               bool                       `json:"show_uptime_section,omitempty"`
+	ShowUptimeSLA                   bool                       `json:"show_uptime_sla,omitempty"`
+	ShowResponseTimeSection         bool                       `json:"show_response_time_section,omitempty"`
+	ShowResponseTimeSLA             bool                       `json:"show_response_time_sla,omitempty"`
+	UptimeSectionSort               string                     `json:"uptime_section_sort,omitempty"`
+	ResponseTimeSectionSort         string                     `json:"response_time_section_sort,omitempty"`
+}
+
+func (s SLAReport) PrimaryKey() PrimaryKey {
+	return PrimaryKey(s.PK)
+}
+
+type SLAReportListOptions struct {
+	Page     int64  `url:"page,omitempty"`
+	PageSize int64  `url:"page_size,omitempty"`
+	Search   string `url:"search,omitempty"`
+	Ordering string `url:"ordering,omitempty"`
+}
+
+type SLAReportListResponse struct {
+	Count   int64       `json:"count,omitempty"`
+	Results []SLAReport `json:"results,omitempty"`
+}
+
+func (r SLAReportListResponse) List() []SLAReport {
+	return r.Results
+}
+
+type SLAReportResponse SLAReport
+
+func (r SLAReportResponse) Item() SLAReport {
+	return SLAReport(r)
+}
+
+type SLAReportCreateUpdateResponse struct {
+	Results SLAReport `json:"results,omitempty"`
+}
+
+func (r SLAReportCreateUpdateResponse) Item() SLAReport {
+	return r.Results
+}
+
+type SLAReportsEndpoint interface {
+	List(context.Context, SLAReportListOptions) ([]SLAReport, error)
+	Create(context.Context, SLAReport) (*SLAReport, error)
+	Update(context.Context, PrimaryKeyable, SLAReport) (*SLAReport, error)
+	Get(context.Context, PrimaryKeyable) (*SLAReport, error)
+	Delete(context.Context, PrimaryKeyable) error
+}
+
+func NewSLAReportsEndpoint(cbd CBD) SLAReportsEndpoint {
+	const endpoint = "sla-reports"
+	return &slaReportEndpointImpl{
+		EndpointLister:  NewEndpointLister[SLAReportListResponse, SLAReport, SLAReportListOptions](cbd, endpoint),
+		EndpointCreator: NewEndpointCreator[SLAReport, SLAReportCreateUpdateResponse](cbd, endpoint),
+		EndpointUpdater: NewEndpointUpdater[SLAReport, SLAReportCreateUpdateResponse](cbd, endpoint),
+		EndpointGetter:  NewEndpointGetter[SLAReportResponse](cbd, endpoint),
+		EndpointDeleter: NewEndpointDeleter(cbd, endpoint),
+	}
+}
+
+type slaReportEndpointImpl struct {
+	EndpointLister[SLAReportListResponse, SLAReport, SLAReportListOptions]
+	EndpointCreator[SLAReport, SLAReportCreateUpdateResponse, SLAReport]
+	EndpointUpdater[SLAReport, SLAReportCreateUpdateResponse, SLAReport]
+	EndpointGetter[SLAReportResponse, SLAReport]
+	EndpointDeleter
+}

--- a/pkg/upapi/ep_slareports_reporting_groups.go
+++ b/pkg/upapi/ep_slareports_reporting_groups.go
@@ -1,0 +1,67 @@
+package upapi
+
+import (
+	"context"
+)
+
+type SLAReportGroup struct {
+	ID            int      `json:"id,omitempty"`
+	Name          string   `json:"name,omitempty"`
+	GroupServices []string `json:"group_services,omitempty"`
+}
+
+func (s SLAReportGroup) PrimaryKey() PrimaryKey {
+	return PrimaryKey(s.ID)
+}
+
+type SLAReportGroupListResponse struct {
+	Count   int64            `json:"count,omitempty"`
+	Results []SLAReportGroup `json:"results,omitempty"`
+}
+
+func (r SLAReportGroupListResponse) List() []SLAReportGroup {
+	return r.Results
+}
+
+type SLAReportGroupResponse SLAReportGroup
+
+func (r SLAReportGroupResponse) Item() SLAReportGroup {
+	return SLAReportGroup(r)
+}
+
+type SLAReportGroupCreateResponse struct {
+	Results SLAReportGroup `json:"results,omitempty"`
+}
+
+func (r SLAReportGroupCreateResponse) Item() SLAReportGroup {
+	return r.Results
+}
+
+type SLAReportGroupCreateUpdateResponse struct {
+	Results SLAReportGroup `json:"results,omitempty"`
+}
+
+func (r SLAReportGroupCreateUpdateResponse) Item() SLAReportGroup {
+	return r.Results
+}
+
+type SLAReportGroupListOptions struct {
+	Page     int64  `url:"page,omitempty"`
+	PageSize int64  `url:"page_size,omitempty"`
+	Search   string `url:"search,omitempty"`
+	Ordering string `url:"ordering,omitempty"`
+}
+
+type SLAReportsGroupsEndpoint interface {
+	Create(context.Context, SLAReportGroup) (*SLAReportGroup, error)
+	List(context.Context, SLAReportGroupListOptions) ([]SLAReportGroup, error)
+	Get(context.Context, PrimaryKeyable) (*SLAReportGroup, error)
+	Delete(context.Context, PrimaryKeyable) error
+}
+
+type slaReportsGroupsEndpointImpl struct {
+	EndpointLister[SLAReportGroupListResponse, SLAReportGroup, SLAReportGroupListOptions]
+	EndpointCreator[SLAReportGroup, SLAReportGroupCreateResponse, SLAReportGroup]
+	EndpointGetter[SLAReportGroupResponse, SLAReportGroup]
+	EndpointDeleter
+}


### PR DESCRIPTION
As the API is inconsistent and can return int IDs in the `services_selected` field, this patch adds a workaround. The `services_selected` field is converted to a complex type, which contains ID and Name fields, to handle one of the types.

https://uptimedotcom.atlassian.net/browse/SYS-31