### PR TITLE
Remove "omitempty" tag from Encryption field for HTTP checks

### DIFF
--- a/pkg/upapi/ep_checks.go
+++ b/pkg/upapi/ep_checks.go
@@ -563,7 +563,7 @@ type CheckHTTP struct {
 	SendString             string          `json:"msp_send_string,omitempty"`
 	ExpectString           string          `json:"msp_expect_string,omitempty"`
 	ExpectStringType       string          `json:"msp_expect_string_type,omitempty"`
-	Encryption             string          `json:"msp_encryption,omitempty"`
+	Encryption             string          `json:"msp_encryption"`
 	Threshold              int64           `json:"msp_threshold,omitempty"`
 	Headers                string          `json:"msp_headers,omitempty"`
 	Version                int64           `json:"msp_version,omitempty"`


### PR DESCRIPTION
Currently we're unable to disable SSL/TLS validation when adding an uptime_check_http resource type using the Uptime Terraform Provider.

For example, the following will result in setting "encryption" to "SSL_TLS" since an empty string is omitted by the go client.

```
resource "uptime_check_http" "http_internal_dev_server_8101" {
  name           = "http_internal_dev_server_8101"
  address        = "https://server:8101"
  port           = "8101"
  tags           = ["someTag"]
  encryption     = ""
  interval       = 3
}
```

A similar fix was added in https://github.com/uptime-com/uptime-client-go/pull/13