### PR TITLE
feat: sys-444 handle credentials

### DIFF
--- a/internal/upctl/cli_credentials.go
+++ b/internal/upctl/cli_credentials.go
@@ -1,0 +1,127 @@
+package upctl
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/uptime-com/uptime-client-go/v2/pkg/upapi"
+)
+
+var credentialsCmd = &cobra.Command{
+	Use:   "credentials",
+	Short: "Manage credentials",
+}
+
+func init() {
+	cmd.AddCommand(credentialsCmd)
+}
+
+var (
+	credentialsListFlags = upapi.CredentialListOptions{
+		Page:     1,
+		PageSize: 100,
+		Ordering: "pk",
+	}
+	credentialsListCmd = &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List credentials",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return output(credentialsList(cmd.Context()))
+		},
+	}
+)
+
+func init() {
+	err := Bind(credentialsListCmd.Flags(), &credentialsListFlags)
+	if err != nil {
+		panic(err)
+	}
+	credentialsCmd.AddCommand(credentialsListCmd)
+}
+
+func credentialsList(ctx context.Context) ([]upapi.Credential, error) {
+	return api.Credentials().List(ctx, credentialsListFlags)
+}
+
+var (
+	credentialsCreateFlags = upapi.Credential{}
+	credentialsCreateCmd   = &cobra.Command{
+		Use:     "create <type>",
+		Aliases: []string{"add"},
+		Short:   "Create a new check",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return output(credentialsCreate(cmd.Context()))
+		},
+	}
+)
+
+func init() {
+	err := Bind(credentialsCreateCmd.Flags(), &credentialsCreateFlags)
+	if err != nil {
+		panic(err)
+	}
+	credentialsCmd.AddCommand(credentialsCreateCmd)
+}
+
+func credentialsCreate(ctx context.Context) (*upapi.Credential, error) {
+	return api.Credentials().Create(ctx, credentialsCreateFlags)
+}
+
+var (
+	credentialsUpdateFlags = upapi.Credential{}
+	credentialsUpdateCmd   = &cobra.Command{
+		Use:     "update <pk>",
+		Aliases: []string{"up"},
+		Short:   "Update existing credential",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return output(credentialsUpdate(cmd.Context(), args[0]))
+		},
+	}
+)
+
+func init() {
+	err := Bind(credentialsUpdateCmd.Flags(), &credentialsUpdateFlags)
+	if err != nil {
+		panic(err)
+	}
+	credentialsCmd.AddCommand(credentialsUpdateCmd)
+}
+
+func credentialsUpdate(ctx context.Context, arg string) (*upapi.Credential, error) {
+	pk, err := parsePK(arg)
+	if err != nil {
+		return nil, err
+	}
+	return api.Credentials().Update(ctx, upapi.PrimaryKey(pk), credentialsUpdateFlags)
+}
+
+var credentialsDeleteCmd = &cobra.Command{
+	Use:     "delete",
+	Aliases: []string{"del", "rm"},
+	Short:   "Delete a tag",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return output(credentialsDelete(cmd.Context(), args[0]))
+	},
+}
+
+func init() {
+	credentialsCmd.AddCommand(credentialsDeleteCmd)
+}
+
+func credentialsDelete(ctx context.Context, pkstr string) (*upapi.Credential, error) {
+	pk, err := parsePK(pkstr)
+	if err != nil {
+		return nil, err
+	}
+	obj, err := api.Credentials().Get(ctx, upapi.PrimaryKey(pk))
+	if err != nil {
+		return nil, err
+	}
+	return obj, api.Credentials().Delete(ctx, upapi.PrimaryKey(pk))
+}

--- a/pkg/upapi/api.go
+++ b/pkg/upapi/api.go
@@ -23,6 +23,7 @@ type API interface {
 	StatusPages() StatusPagesEndpoint
 	SLAReports() SLAReportsEndpoint
 	ScheduledReports() ScheduledReportsEndpoint
+	Credentials() CredentialEndpoint
 }
 
 // New returns a new API client instance.
@@ -129,4 +130,8 @@ func (api *apiImpl) SLAReports() SLAReportsEndpoint {
 
 func (api *apiImpl) ScheduledReports() ScheduledReportsEndpoint {
 	return api.scheduledReports
+}
+
+func (api *apiImpl) Credentials() CredentialEndpoint {
+	return NewCredentialsEndpoint(api.CBD)
 }

--- a/pkg/upapi/ep_credentials.go
+++ b/pkg/upapi/ep_credentials.go
@@ -1,0 +1,84 @@
+package upapi
+
+import (
+	"context"
+)
+
+type CredentialSecret struct {
+	Certificate string `json:"certificate,omitempty"`
+	Key         string `json:"key,omitempty"`
+	Password    string `json:"password,omitempty"`
+	Passphrase  string `json:"passphrase,omitempty"`
+	Secret      string `json:"secret,omitempty"`
+}
+
+type Credential struct {
+	PK             int64            `json:"id,omitempty"`
+	DisplayName    string           `json:"display_name,omitempty"`
+	Description    string           `json:"description,omitempty"`
+	CredentialType string           `json:"credential_type"`
+	Username       string           `json:"username,omitempty"`
+	Secret         CredentialSecret `json:"secret"`
+}
+
+func (c Credential) PrimaryKey() PrimaryKey {
+	return PrimaryKey(c.PK)
+}
+
+type CredentialListOptions struct {
+	Page              int64  `url:"page,omitempty"`
+	PageSize          int64  `url:"page_size,omitempty"`
+	Search            string `url:"search,omitempty"`
+	Ordering          string `url:"ordering,omitempty"`
+	HasOnCallSchedule bool   `url:"has_on_call_schedule,omitempty"`
+}
+
+type CredentialListResponse struct {
+	Count   int64        `json:"count,omitempty"`
+	Results []Credential `json:"results,omitempty"`
+}
+
+func (r CredentialListResponse) List() []Credential {
+	return r.Results
+}
+
+type CredentialResponse Credential
+
+func (r CredentialResponse) Item() Credential {
+	return Credential(r)
+}
+
+type CredentialCreateUpdateResponse struct {
+	Results Credential `json:"results,omitempty"`
+}
+
+func (r CredentialCreateUpdateResponse) Item() Credential {
+	return r.Results
+}
+
+type CredentialEndpoint interface {
+	List(context.Context, CredentialListOptions) ([]Credential, error)
+	Create(context.Context, Credential) (*Credential, error)
+	Update(context.Context, PrimaryKeyable, Credential) (*Credential, error)
+	Get(context.Context, PrimaryKeyable) (*Credential, error)
+	Delete(context.Context, PrimaryKeyable) error
+}
+
+func NewCredentialsEndpoint(cbd CBD) CredentialEndpoint {
+	const endpoint = "credentials"
+	return &credentialsEndpointImpl{
+		EndpointLister:  NewEndpointLister[CredentialListResponse, Credential, CredentialListOptions](cbd, endpoint),
+		EndpointCreator: NewEndpointCreator[Credential, CredentialCreateUpdateResponse](cbd, endpoint),
+		EndpointUpdater: NewEndpointUpdater[Credential, CredentialCreateUpdateResponse](cbd, endpoint),
+		EndpointGetter:  NewEndpointGetter[CredentialResponse](cbd, endpoint),
+		EndpointDeleter: NewEndpointDeleter(cbd, endpoint),
+	}
+}
+
+type credentialsEndpointImpl struct {
+	EndpointLister[CredentialListResponse, Credential, CredentialListOptions]
+	EndpointCreator[Credential, CredentialCreateUpdateResponse, Credential]
+	EndpointUpdater[Credential, CredentialCreateUpdateResponse, Credential]
+	EndpointGetter[CredentialResponse, Credential]
+	EndpointDeleter
+}


### PR DESCRIPTION
Added new commands to manage credentials including list, create, update, and delete. Implemented the necessary endpoints in the upapi package to support these operations.