### PR TITLE
SYS-411: fix dashboard update 

### DIFF
--- a/pkg/upapi/ep_dashboards.go
+++ b/pkg/upapi/ep_dashboards.go
@@ -3,7 +3,7 @@ package upapi
 import "context"
 
 type Dashboard struct {
-	PK                         int64    `json:"pk"`
+	PK                         int64    `json:"pk,omitempty"`
 	ServicesSelected           []string `json:"services_selected"`
 	ServicesTags               []string `json:"services_tags"`
 	Ordering                   int64    `json:"ordering"`

--- a/pkg/upapi/ep_statuspages_incidents.go
+++ b/pkg/upapi/ep_statuspages_incidents.go
@@ -32,8 +32,8 @@ type StatusPageIncident struct {
 	AffectedComponents []IncidentAffectedComponentEntity `json:"affected_components,omitempty"`
 
 	IncidentType                     string `json:"incident_type,omitempty"`
-	StartsAt                         string `json:"starts_at,omitempty"`
-	EndsAt                           string `json:"ends_at"`
+	StartsAt                         string `json:"starts_at"`
+	EndsAt                           string `json:"ends_at,omitempty"`
 	UpdateComponentStatus            bool   `json:"update_component_status,omitempty"`
 	NotifySubscribers                bool   `json:"notify_subscribers,omitempty"`
 	SendMaintenanceStartNotification bool   `json:"send_maintenance_start_notification,omitempty"`


### PR DESCRIPTION
The PATCH method fails if PK fails with the wrong message, even with a zero value present in the request's body.