### PR TITLE
feat: SYS-978 add service variables support

### DIFF
--- a/internal/upctl/cli_service_variables.go
+++ b/internal/upctl/cli_service_variables.go
@@ -1,0 +1,157 @@
+package upctl
+
+import (
+	"context"
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"github.com/uptime-com/uptime-client-go/v2/pkg/upapi"
+)
+
+var serviceVariablesCmd = &cobra.Command{
+	Use:     "servicevariables",
+	Aliases: []string{"servicevariable", "sv", "svar"},
+	Short:   "Manage service variables",
+	Args:    cobra.NoArgs,
+}
+
+func init() {
+	cmd.AddCommand(serviceVariablesCmd)
+}
+
+var (
+	serviceVariablesListFlags = upapi.ServiceVariableListOptions{
+		Page:     1,
+		PageSize: 100,
+		Ordering: "pk",
+	}
+	serviceVariablesListCmd = &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List service variables",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return output(serviceVariablesList(cmd.Context()))
+		},
+	}
+)
+
+func init() {
+	err := Bind(serviceVariablesListCmd.Flags(), &serviceVariablesListFlags)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	serviceVariablesCmd.AddCommand(serviceVariablesListCmd)
+}
+
+func serviceVariablesList(ctx context.Context) ([]upapi.ServiceVariable, error) {
+	return api.ServiceVariables().List(ctx, serviceVariablesListFlags)
+}
+
+var (
+	serviceVariablesGetCmd = &cobra.Command{
+		Use:     "get <pk>",
+		Aliases: []string{"show"},
+		Short:   "Get a service variable",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return output(serviceVariablesGet(cmd.Context(), args[0]))
+		},
+	}
+)
+
+func init() {
+	serviceVariablesCmd.AddCommand(serviceVariablesGetCmd)
+}
+
+func serviceVariablesGet(ctx context.Context, pkstr string) (*upapi.ServiceVariable, error) {
+	pk, err := parsePK(pkstr)
+	if err != nil {
+		return nil, err
+	}
+	return api.ServiceVariables().Get(ctx, upapi.PrimaryKey(pk))
+}
+
+var (
+	serviceVariablesCreateFlags upapi.ServiceVariableCreateRequest
+	serviceVariablesCreateCmd   = &cobra.Command{
+		Use:     "create",
+		Aliases: []string{"new"},
+		Short:   "Create a new service variable",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return output(serviceVariablesCreate(cmd.Context()))
+		},
+	}
+)
+
+func init() {
+	err := Bind(serviceVariablesCreateCmd.Flags(), &serviceVariablesCreateFlags)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	serviceVariablesCmd.AddCommand(serviceVariablesCreateCmd)
+}
+
+func serviceVariablesCreate(ctx context.Context) (*upapi.ServiceVariable, error) {
+	return api.ServiceVariables().Create(ctx, serviceVariablesCreateFlags)
+}
+
+var (
+	serviceVariablesUpdateFlags upapi.ServiceVariableUpdateRequest
+	serviceVariablesUpdateCmd   = &cobra.Command{
+		Use:     "update <pk>",
+		Aliases: []string{"up"},
+		Short:   "Update a service variable",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return output(serviceVariablesUpdate(cmd.Context(), args[0]))
+		},
+	}
+)
+
+func init() {
+	err := Bind(serviceVariablesUpdateCmd.Flags(), &serviceVariablesUpdateFlags)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	serviceVariablesCmd.AddCommand(serviceVariablesUpdateCmd)
+}
+
+func serviceVariablesUpdate(ctx context.Context, pkstr string) (*upapi.ServiceVariable, error) {
+	pk, err := parsePK(pkstr)
+	if err != nil {
+		return nil, err
+	}
+	return api.ServiceVariables().Update(ctx, upapi.PrimaryKey(pk), serviceVariablesUpdateFlags)
+}
+
+var (
+	serviceVariablesDeleteCmd = &cobra.Command{
+		Use:     "delete <pk>",
+		Aliases: []string{"del", "rm", "remove"},
+		Short:   "Delete a service variable",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return output(serviceVariablesDelete(cmd.Context(), args[0]))
+		},
+	}
+)
+
+func init() {
+	serviceVariablesCmd.AddCommand(serviceVariablesDeleteCmd)
+}
+
+func serviceVariablesDelete(ctx context.Context, pkstr string) (*upapi.ServiceVariable, error) {
+	pk, err := parsePK(pkstr)
+	if err != nil {
+		return nil, err
+	}
+	sv, err := api.ServiceVariables().Get(ctx, upapi.PrimaryKey(pk))
+	if err != nil {
+		return nil, err
+	}
+	return sv, api.ServiceVariables().Delete(ctx, upapi.PrimaryKey(pk))
+}
+

--- a/pkg/upapi/api.go
+++ b/pkg/upapi/api.go
@@ -24,6 +24,7 @@ type API interface {
 	SLAReports() SLAReportsEndpoint
 	ScheduledReports() ScheduledReportsEndpoint
 	Credentials() CredentialEndpoint
+	ServiceVariables() ServiceVariablesEndpoint
 }
 
 // New returns a new API client instance.
@@ -74,6 +75,7 @@ func New(opts ...Option) (api API, err error) {
 		statusPages:      NewStatusPagesEndpoint(cbd),
 		slaReports:       NewSLAReportsEndpoint(cbd),
 		scheduledReports: NewScheduledReportsEndpoint(cbd),
+		serviceVariables: NewServiceVariablesEndpoint(cbd),
 	}
 	return api, nil
 }
@@ -90,6 +92,7 @@ type apiImpl struct {
 	statusPages      StatusPagesEndpoint
 	slaReports       SLAReportsEndpoint
 	scheduledReports ScheduledReportsEndpoint
+	serviceVariables ServiceVariablesEndpoint
 }
 
 func (api *apiImpl) Checks() ChecksEndpoint {
@@ -134,4 +137,8 @@ func (api *apiImpl) ScheduledReports() ScheduledReportsEndpoint {
 
 func (api *apiImpl) Credentials() CredentialEndpoint {
 	return NewCredentialsEndpoint(api.CBD)
+}
+
+func (api *apiImpl) ServiceVariables() ServiceVariablesEndpoint {
+	return api.serviceVariables
 }

--- a/pkg/upapi/ep_credentials.go
+++ b/pkg/upapi/ep_credentials.go
@@ -13,12 +13,16 @@ type CredentialSecret struct {
 }
 
 type Credential struct {
-	PK             int64            `json:"id,omitempty"`
-	DisplayName    string           `json:"display_name,omitempty"`
-	Description    string           `json:"description,omitempty"`
-	CredentialType string           `json:"credential_type"`
-	Username       string           `json:"username,omitempty"`
-	Secret         CredentialSecret `json:"secret"`
+	PK                   int64            `json:"id,omitempty"`
+	DisplayName          string           `json:"display_name,omitempty"`
+	Description          string           `json:"description,omitempty"`
+	CredentialType       string           `json:"credential_type"`
+	Hint                 string           `json:"hint,omitempty"`
+	Username             string           `json:"username,omitempty"`
+	Version              string           `json:"version,omitempty"`
+	UsedSecretProperties []string         `json:"used_secret_properties,omitempty"`
+	CreatedBy            int64            `json:"created_by,omitempty"`
+	Secret               CredentialSecret `json:"secret"`
 }
 
 func (c Credential) PrimaryKey() PrimaryKey {

--- a/pkg/upapi/ep_service_variables.go
+++ b/pkg/upapi/ep_service_variables.go
@@ -1,0 +1,108 @@
+package upapi
+
+import (
+	"context"
+	"time"
+)
+
+type ServiceVariableCredential struct {
+	ID                   int64    `json:"id,omitempty"`
+	CredentialType       string   `json:"credential_type,omitempty"`
+	DisplayName          string   `json:"display_name,omitempty"`
+	Description          string   `json:"description,omitempty"`
+	Hint                 string   `json:"hint,omitempty"`
+	Username             string   `json:"username,omitempty"`
+	Version              string   `json:"version,omitempty"`
+	UsedSecretProperties []string `json:"used_secret_properties,omitempty"`
+	CreatedBy            int64    `json:"created_by,omitempty"`
+}
+
+type ServiceVariable struct {
+	ID           int64                      `json:"id,omitempty"`
+	CredentialID int64                      `json:"credential_id,omitempty"`
+	Credential   *ServiceVariableCredential `json:"credential,omitempty"`
+	PropertyName string                     `json:"property_name,omitempty"`
+	VariableName string                     `json:"variable_name,omitempty"`
+	DeletedAt    *time.Time                 `json:"deleted_at,omitempty"`
+	Account      string                     `json:"account,omitempty"`
+	Service      string                     `json:"service,omitempty"`
+}
+
+func (s ServiceVariable) PrimaryKey() PrimaryKey {
+	return PrimaryKey(s.ID)
+}
+
+type ServiceVariableListResponse struct {
+	Count    int64             `json:"count,omitempty"`
+	Next     string            `json:"next,omitempty"`
+	Previous string            `json:"previous,omitempty"`
+	Results  []ServiceVariable `json:"results,omitempty"`
+}
+
+func (r ServiceVariableListResponse) List() []ServiceVariable {
+	return r.Results
+}
+
+type ServiceVariableListOptions struct {
+	Page     int64  `url:"page,omitempty"`
+	PageSize int64  `url:"page_size,omitempty"`
+	Search   string `url:"search,omitempty"`
+	Ordering string `url:"ordering,omitempty"`
+}
+
+type ServiceVariableItemResponse struct {
+	Results ServiceVariable `json:"results,omitempty"`
+}
+
+func (s ServiceVariableItemResponse) Item() ServiceVariable {
+	return s.Results
+}
+
+type ServiceVariableCreateUpdateResponse struct {
+	Results ServiceVariable `json:"results,omitempty"`
+}
+
+func (s ServiceVariableCreateUpdateResponse) Item() ServiceVariable {
+	return s.Results
+}
+
+type ServiceVariableCreateRequest struct {
+	CredentialID int64  `json:"credential_id" flag:"credential-id"`
+	PropertyName string `json:"property_name" flag:"property-name"`
+	ServiceID    int64  `json:"service_id" flag:"service-id"`
+	VariableName string `json:"variable_name" flag:"variable-name"`
+}
+
+type ServiceVariableUpdateRequest struct {
+	CredentialID int64  `json:"credential_id,omitempty" flag:"credential-id"`
+	PropertyName string `json:"property_name,omitempty" flag:"property-name"`
+	ServiceID    int64  `json:"service_id,omitempty" flag:"service-id"`
+	VariableName string `json:"variable_name,omitempty" flag:"variable-name"`
+}
+
+type ServiceVariablesEndpoint interface {
+	List(context.Context, ServiceVariableListOptions) ([]ServiceVariable, error)
+	Create(context.Context, ServiceVariableCreateRequest) (*ServiceVariable, error)
+	Get(context.Context, PrimaryKeyable) (*ServiceVariable, error)
+	Update(context.Context, PrimaryKeyable, ServiceVariableUpdateRequest) (*ServiceVariable, error)
+	Delete(context.Context, PrimaryKeyable) error
+}
+
+func NewServiceVariablesEndpoint(cbd CBD) ServiceVariablesEndpoint {
+	const endpoint = "servicevariables"
+	return &serviceVariablesEndpointImpl{
+		EndpointLister:  NewEndpointLister[ServiceVariableListResponse, ServiceVariable, ServiceVariableListOptions](cbd, endpoint),
+		EndpointGetter:  NewEndpointGetter[ServiceVariableItemResponse, ServiceVariable](cbd, endpoint),
+		EndpointCreator: NewEndpointCreator[ServiceVariableCreateRequest, ServiceVariableCreateUpdateResponse, ServiceVariable](cbd, endpoint),
+		EndpointUpdater: NewEndpointUpdater[ServiceVariableUpdateRequest, ServiceVariableCreateUpdateResponse, ServiceVariable](cbd, endpoint),
+		EndpointDeleter: NewEndpointDeleter(cbd, endpoint),
+	}
+}
+
+type serviceVariablesEndpointImpl struct {
+	EndpointLister[ServiceVariableListResponse, ServiceVariable, ServiceVariableListOptions]
+	EndpointGetter[ServiceVariableItemResponse, ServiceVariable]
+	EndpointCreator[ServiceVariableCreateRequest, ServiceVariableCreateUpdateResponse, ServiceVariable]
+	EndpointUpdater[ServiceVariableUpdateRequest, ServiceVariableCreateUpdateResponse, ServiceVariable]
+	EndpointDeleter
+}


### PR DESCRIPTION
Add complete implementation for Uptime.com Service Variables API including:
- Service Variables endpoint with full CRUD operations
- CLI commands for managing service variables (list, get, create, update, delete)
- Support for credential-based service variable management
- Proper request/response structures matching actual API