### PR TITLE
feat: cloudstatus group monitoring + error_fields/encryption decode fixes (SYS-1201)

### DIFF
--- a/internal/upctl/utils.go
+++ b/internal/upctl/utils.go
@@ -16,6 +16,7 @@ type FlagSet interface {
 	Float64VarP(ptr *float64, name, shorthand string, value float64, usage string)
 	BoolVarP(ptr *bool, name, shorthand string, value bool, usage string)
 	StringSliceVarP(ptr *[]string, name, shorthand string, value []string, usage string)
+	Int64SliceVarP(ptr *[]int64, name, shorthand string, value []int64, usage string)
 }
 
 func Bind(fs FlagSet, obj any) error {
@@ -77,6 +78,9 @@ func Bind(fs FlagSet, obj any) error {
 		case t.Field(i).Type.Kind() == reflect.Slice && t.Field(i).Type.Elem().Kind() == reflect.String:
 			ptr, val := ptrVal[[]string](vf)
 			fs.StringSliceVarP(ptr, flag, short, val, usage)
+		case t.Field(i).Type.Kind() == reflect.Slice && t.Field(i).Type.Elem().Kind() == reflect.Int64:
+			ptr, val := ptrVal[[]int64](vf)
+			fs.Int64SliceVarP(ptr, flag, short, val, usage)
 		// Handle *[]string - pointer to string slice (already initialized above)
 		case t.Field(i).Type.Kind() == reflect.Ptr && t.Field(i).Type.Elem().Kind() == reflect.Slice && t.Field(i).Type.Elem().Elem().Kind() == reflect.String:
 			innerSlice := vf.Elem()

--- a/internal/upctl/utils_test.go
+++ b/internal/upctl/utils_test.go
@@ -33,6 +33,10 @@ func (f *flagSetMock) StringSliceVarP(ptr *[]string, name, shorthand string, val
 	f.Called(ptr, name, shorthand, value, usage)
 }
 
+func (f *flagSetMock) Int64SliceVarP(ptr *[]int64, name, shorthand string, value []int64, usage string) {
+	f.Called(ptr, name, shorthand, value, usage)
+}
+
 func (f *flagSetMock) Float64VarP(ptr *float64, name, shorthand string, value float64, usage string) {
 	f.Called(ptr, name, shorthand, value, usage)
 }

--- a/pkg/upapi/ep_checks.go
+++ b/pkg/upapi/ep_checks.go
@@ -76,7 +76,7 @@ type Check struct {
 	SendString             string            `json:"msp_send_string,omitempty"`
 	ExpectString           string            `json:"msp_expect_string,omitempty"`
 	ExpectStringType       string            `json:"msp_expect_string_type,omitempty"`
-	Encryption             string            `json:"msp_encryption"`
+	Encryption             *string           `json:"msp_encryption,omitempty"`
 	Threshold              int64             `json:"msp_threshold,omitempty"`
 	Headers                string            `json:"msp_headers,omitempty"`
 	Script                 string            `json:"msp_script,omitempty"`

--- a/pkg/upapi/ep_checks.go
+++ b/pkg/upapi/ep_checks.go
@@ -76,7 +76,7 @@ type Check struct {
 	SendString             string            `json:"msp_send_string,omitempty"`
 	ExpectString           string            `json:"msp_expect_string,omitempty"`
 	ExpectStringType       string            `json:"msp_expect_string_type,omitempty"`
-	Encryption             string            `json:"msp_encryption,omitempty"`
+	Encryption             string            `json:"msp_encryption"`
 	Threshold              int64             `json:"msp_threshold,omitempty"`
 	Headers                string            `json:"msp_headers,omitempty"`
 	Script                 string            `json:"msp_script,omitempty"`

--- a/pkg/upapi/ep_checks_cloudstatus.go
+++ b/pkg/upapi/ep_checks_cloudstatus.go
@@ -1,6 +1,46 @@
 package upapi
 
-import "context"
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+)
+
+// CloudStatusGroup references a cloud status group by ID. On write
+// (POST/PUT) it serializes as the group's integer ID, matching the legacy
+// request format. On read (GET) the server returns a nested
+// `{"id": ..., "name": ...}` object, so UnmarshalJSON accepts either
+// shape - bare integer or nested object.
+type CloudStatusGroup struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name,omitempty"`
+}
+
+func (g CloudStatusGroup) MarshalJSON() ([]byte, error) {
+	return json.Marshal(g.ID)
+}
+
+func (g *CloudStatusGroup) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return nil
+	}
+	if trimmed[0] == '{' {
+		type raw CloudStatusGroup
+		var r raw
+		if err := json.Unmarshal(data, &r); err != nil {
+			return err
+		}
+		*g = CloudStatusGroup(r)
+		return nil
+	}
+	var id int64
+	if err := json.Unmarshal(data, &id); err != nil {
+		return err
+	}
+	g.ID = id
+	return nil
+}
 
 // CheckCloudStatusConfig describes the cloudstatusconfig payload accepted by
 // the /checks/add-cloudstatus and /checks/{pk} endpoints.
@@ -22,8 +62,9 @@ type CheckCloudStatusConfig struct {
 	// ServiceName is the legacy (deprecated) cloud status component name or ID.
 	ServiceName string `json:"service_name,omitempty"`
 
-	// Group is the cloud status group ID to monitor. Write-only on the server.
-	Group *int64 `json:"group,omitempty"`
+	// Group is the cloud status group to monitor. On write only the numeric
+	// ID is sent; on read the server also reports the group name.
+	Group *CloudStatusGroup `json:"group,omitempty"`
 
 	// MonitoringType selects how Group is monitored: "ALL" or "SPECIFIC".
 	MonitoringType string `json:"monitoring_type,omitempty"`

--- a/pkg/upapi/ep_checks_cloudstatus.go
+++ b/pkg/upapi/ep_checks_cloudstatus.go
@@ -2,8 +2,39 @@ package upapi
 
 import "context"
 
+// CheckCloudStatusConfig describes the cloudstatusconfig payload accepted by
+// the /checks/add-cloudstatus and /checks/{pk} endpoints.
+//
+// There are two ways to configure what is monitored:
+//
+//  1. Legacy: set ServiceName to a single component name. Deprecated server-side
+//     in favour of the group + monitoring_type model below.
+//  2. Group-based: set Group to the cloud status group ID and MonitoringType to
+//     either "ALL" (every service in the group) or "SPECIFIC" (only entries
+//     listed in Services and/or ServiceTitles).
+//
+// Use the GET /api/v1/checks/cloudstatus-groups/ and
+// /api/v1/checks/cloudstatus-services/ endpoints to discover valid IDs.
 type CheckCloudStatusConfig struct {
+	// NotifyOnlyOnDown opts out of maintenance notifications.
+	NotifyOnlyOnDown bool `json:"notify_only_on_down,omitempty"`
+
+	// ServiceName is the legacy (deprecated) cloud status component name or ID.
 	ServiceName string `json:"service_name,omitempty"`
+
+	// Group is the cloud status group ID to monitor. Write-only on the server.
+	Group *int64 `json:"group,omitempty"`
+
+	// MonitoringType selects how Group is monitored: "ALL" or "SPECIFIC".
+	MonitoringType string `json:"monitoring_type,omitempty"`
+
+	// Services is the list of specific service IDs to monitor when
+	// MonitoringType is "SPECIFIC".
+	Services []int64 `json:"services,omitempty"`
+
+	// ServiceTitles auto-monitors current and future services whose title
+	// matches any entry in this list when MonitoringType is "SPECIFIC".
+	ServiceTitles []string `json:"service_titles,omitempty"`
 }
 
 type CheckCloudStatus struct {

--- a/pkg/upapi/ep_checks_cloudstatus.go
+++ b/pkg/upapi/ep_checks_cloudstatus.go
@@ -21,6 +21,7 @@ func (g CloudStatusGroup) MarshalJSON() ([]byte, error) {
 }
 
 func (g *CloudStatusGroup) UnmarshalJSON(data []byte) error {
+	*g = CloudStatusGroup{}
 	trimmed := bytes.TrimSpace(data)
 	if len(trimmed) == 0 || string(trimmed) == "null" {
 		return nil

--- a/pkg/upapi/ep_checks_cloudstatus_test.go
+++ b/pkg/upapi/ep_checks_cloudstatus_test.go
@@ -1,0 +1,57 @@
+package upapi
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloudStatusGroup(t *testing.T) {
+	t.Run("marshals as integer ID", func(t *testing.T) {
+		g := CloudStatusGroup{ID: 3742, Name: "Amazon"}
+		data, err := json.Marshal(&g)
+		require.NoError(t, err)
+		require.Equal(t, "3742", string(data))
+	})
+	t.Run("unmarshals from integer", func(t *testing.T) {
+		var g CloudStatusGroup
+		require.NoError(t, json.Unmarshal([]byte(`3742`), &g))
+		require.Equal(t, int64(3742), g.ID)
+		require.Empty(t, g.Name)
+	})
+	t.Run("unmarshals from object", func(t *testing.T) {
+		var g CloudStatusGroup
+		require.NoError(t, json.Unmarshal([]byte(`{"id": 3742, "name": "Amazon"}`), &g))
+		require.Equal(t, int64(3742), g.ID)
+		require.Equal(t, "Amazon", g.Name)
+	})
+	t.Run("unmarshals null", func(t *testing.T) {
+		var g CloudStatusGroup
+		require.NoError(t, json.Unmarshal([]byte(`null`), &g))
+		require.Equal(t, int64(0), g.ID)
+	})
+	t.Run("round-trips inside CheckCloudStatusConfig response", func(t *testing.T) {
+		body := []byte(`{
+			"monitoring_type": "ALL",
+			"group": {"id": 3742, "name": "Amazon"},
+			"services": [],
+			"service_titles": []
+		}`)
+		var cfg CheckCloudStatusConfig
+		require.NoError(t, json.Unmarshal(body, &cfg))
+		require.NotNil(t, cfg.Group)
+		require.Equal(t, int64(3742), cfg.Group.ID)
+		require.Equal(t, "Amazon", cfg.Group.Name)
+		require.Equal(t, "ALL", cfg.MonitoringType)
+	})
+	t.Run("marshals request with numeric group ID", func(t *testing.T) {
+		cfg := CheckCloudStatusConfig{
+			Group:          &CloudStatusGroup{ID: 3742},
+			MonitoringType: "ALL",
+		}
+		data, err := json.Marshal(cfg)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"group":3742,"monitoring_type":"ALL"}`, string(data))
+	})
+}

--- a/pkg/upapi/ep_checks_cloudstatus_test.go
+++ b/pkg/upapi/ep_checks_cloudstatus_test.go
@@ -31,6 +31,19 @@ func TestCloudStatusGroup(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(`null`), &g))
 		require.Equal(t, int64(0), g.ID)
 	})
+	t.Run("resets receiver state across reuse", func(t *testing.T) {
+		g := CloudStatusGroup{ID: 999, Name: "stale"}
+		require.NoError(t, json.Unmarshal([]byte(`null`), &g))
+		require.Equal(t, CloudStatusGroup{}, g)
+
+		g = CloudStatusGroup{ID: 999, Name: "stale"}
+		require.NoError(t, json.Unmarshal([]byte(`42`), &g))
+		require.Equal(t, CloudStatusGroup{ID: 42}, g)
+
+		g = CloudStatusGroup{ID: 999, Name: "stale"}
+		require.NoError(t, json.Unmarshal([]byte(`{"id":7,"name":"fresh"}`), &g))
+		require.Equal(t, CloudStatusGroup{ID: 7, Name: "fresh"}, g)
+	})
 	t.Run("round-trips inside CheckCloudStatusConfig response", func(t *testing.T) {
 		body := []byte(`{
 			"monitoring_type": "ALL",

--- a/pkg/upapi/ep_checks_http.go
+++ b/pkg/upapi/ep_checks_http.go
@@ -22,7 +22,7 @@ type CheckHTTP struct {
 	SendString             string          `json:"msp_send_string,omitempty"`
 	ExpectString           string          `json:"msp_expect_string,omitempty"`
 	ExpectStringType       string          `json:"msp_expect_string_type,omitempty"`
-	Encryption             string          `json:"msp_encryption"`
+	Encryption             *string         `json:"msp_encryption,omitempty"`
 	Threshold              int64           `json:"msp_threshold,omitempty"`
 	Headers                string          `json:"msp_headers,omitempty"`
 	Version                int64           `json:"msp_version,omitempty"`

--- a/pkg/upapi/ep_checks_http.go
+++ b/pkg/upapi/ep_checks_http.go
@@ -22,7 +22,7 @@ type CheckHTTP struct {
 	SendString             string          `json:"msp_send_string,omitempty"`
 	ExpectString           string          `json:"msp_expect_string,omitempty"`
 	ExpectStringType       string          `json:"msp_expect_string_type,omitempty"`
-	Encryption             string          `json:"msp_encryption,omitempty"`
+	Encryption             string          `json:"msp_encryption"`
 	Threshold              int64           `json:"msp_threshold,omitempty"`
 	Headers                string          `json:"msp_headers,omitempty"`
 	Version                int64           `json:"msp_version,omitempty"`

--- a/pkg/upapi/ep_checks_imap.go
+++ b/pkg/upapi/ep_checks_imap.go
@@ -16,7 +16,7 @@ type CheckIMAP struct {
 	Address                string          `json:"msp_address,omitempty"`
 	Port                   int64           `json:"msp_port,omitempty"`
 	ExpectString           string          `json:"msp_expect_string,omitempty"`
-	Encryption             string          `json:"msp_encryption"`
+	Encryption             *string         `json:"msp_encryption,omitempty"`
 	Sensitivity            int64           `json:"msp_sensitivity,omitempty"`
 	NumRetries             int64           `json:"msp_num_retries,omitempty"`
 	UseIPVersion           string          `json:"msp_use_ip_version,omitempty"`

--- a/pkg/upapi/ep_checks_imap.go
+++ b/pkg/upapi/ep_checks_imap.go
@@ -16,7 +16,7 @@ type CheckIMAP struct {
 	Address                string          `json:"msp_address,omitempty"`
 	Port                   int64           `json:"msp_port,omitempty"`
 	ExpectString           string          `json:"msp_expect_string,omitempty"`
-	Encryption             string          `json:"msp_encryption,omitempty"`
+	Encryption             string          `json:"msp_encryption"`
 	Sensitivity            int64           `json:"msp_sensitivity,omitempty"`
 	NumRetries             int64           `json:"msp_num_retries,omitempty"`
 	UseIPVersion           string          `json:"msp_use_ip_version,omitempty"`

--- a/pkg/upapi/ep_checks_json_test.go
+++ b/pkg/upapi/ep_checks_json_test.go
@@ -18,10 +18,28 @@ func TestCheckHTTP_OmitsZeroValues(t *testing.T) {
 	if _, ok := m["name"]; !ok {
 		t.Error("expected 'name' to be present")
 	}
-	for _, field := range []string{"msp_address", "msp_status_code", "msp_encryption", "is_paused", "msp_include_in_global_metrics"} {
+	for _, field := range []string{"msp_address", "msp_status_code", "is_paused", "msp_include_in_global_metrics"} {
 		if _, ok := m[field]; ok {
 			t.Errorf("expected %q to be omitted for zero value, but it was present", field)
 		}
+	}
+}
+
+// TestCheckHTTP_EncryptionEmptyStringSent ensures msp_encryption is sent on
+// the wire even when empty so callers can opt out of encryption (the only
+// way to express "Off" - "" - to the server).
+func TestCheckHTTP_EncryptionEmptyStringSent(t *testing.T) {
+	data, err := json.Marshal(CheckHTTP{Name: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := unmarshalToMap(t, data)
+	v, ok := m["msp_encryption"]
+	if !ok {
+		t.Fatal("expected 'msp_encryption' to be present even when empty")
+	}
+	if v != "" {
+		t.Errorf("expected msp_encryption to be empty string, got %v", v)
 	}
 }
 

--- a/pkg/upapi/ep_checks_json_test.go
+++ b/pkg/upapi/ep_checks_json_test.go
@@ -18,29 +18,55 @@ func TestCheckHTTP_OmitsZeroValues(t *testing.T) {
 	if _, ok := m["name"]; !ok {
 		t.Error("expected 'name' to be present")
 	}
-	for _, field := range []string{"msp_address", "msp_status_code", "is_paused", "msp_include_in_global_metrics"} {
+	for _, field := range []string{"msp_address", "msp_status_code", "msp_encryption", "is_paused", "msp_include_in_global_metrics"} {
 		if _, ok := m[field]; ok {
 			t.Errorf("expected %q to be omitted for zero value, but it was present", field)
 		}
 	}
 }
 
-// TestCheckHTTP_EncryptionEmptyStringSent ensures msp_encryption is sent on
-// the wire even when empty so callers can opt out of encryption (the only
-// way to express "Off" - "" - to the server).
-func TestCheckHTTP_EncryptionEmptyStringSent(t *testing.T) {
-	data, err := json.Marshal(CheckHTTP{Name: "test"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	m := unmarshalToMap(t, data)
-	v, ok := m["msp_encryption"]
-	if !ok {
-		t.Fatal("expected 'msp_encryption' to be present even when empty")
-	}
-	if v != "" {
-		t.Errorf("expected msp_encryption to be empty string, got %v", v)
-	}
+// TestCheckHTTP_EncryptionTriState verifies the *string semantics for
+// msp_encryption: nil pointer omits the field (server applies its default),
+// pointer to "" sends an explicit Off, pointer to "SSL_TLS" sends explicit
+// TLS-on. This is the only way to distinguish "use server default" from
+// "explicitly disable encryption".
+func TestCheckHTTP_EncryptionTriState(t *testing.T) {
+	t.Run("nil pointer omits field", func(t *testing.T) {
+		data, err := json.Marshal(CheckHTTP{Name: "test", Encryption: nil})
+		if err != nil {
+			t.Fatal(err)
+		}
+		m := unmarshalToMap(t, data)
+		if _, ok := m["msp_encryption"]; ok {
+			t.Error("expected 'msp_encryption' to be omitted when pointer is nil")
+		}
+	})
+	t.Run("pointer to empty string sends Off", func(t *testing.T) {
+		empty := ""
+		data, err := json.Marshal(CheckHTTP{Name: "test", Encryption: &empty})
+		if err != nil {
+			t.Fatal(err)
+		}
+		m := unmarshalToMap(t, data)
+		v, ok := m["msp_encryption"]
+		if !ok {
+			t.Fatal("expected 'msp_encryption' to be present when pointer is non-nil")
+		}
+		if v != "" {
+			t.Errorf("expected msp_encryption to be empty string, got %v", v)
+		}
+	})
+	t.Run("pointer to SSL_TLS sends TLS-on", func(t *testing.T) {
+		tls := "SSL_TLS"
+		data, err := json.Marshal(CheckHTTP{Name: "test", Encryption: &tls})
+		if err != nil {
+			t.Fatal(err)
+		}
+		m := unmarshalToMap(t, data)
+		if v := m["msp_encryption"]; v != "SSL_TLS" {
+			t.Errorf("expected msp_encryption=\"SSL_TLS\", got %v", v)
+		}
+	})
 }
 
 func TestCheckHTTP_BoolPtrFalse(t *testing.T) {

--- a/pkg/upapi/ep_checks_json_test.go
+++ b/pkg/upapi/ep_checks_json_test.go
@@ -25,48 +25,60 @@ func TestCheckHTTP_OmitsZeroValues(t *testing.T) {
 	}
 }
 
-// TestCheckHTTP_EncryptionTriState verifies the *string semantics for
-// msp_encryption: nil pointer omits the field (server applies its default),
-// pointer to "" sends an explicit Off, pointer to "SSL_TLS" sends explicit
-// TLS-on. This is the only way to distinguish "use server default" from
-// "explicitly disable encryption".
-func TestCheckHTTP_EncryptionTriState(t *testing.T) {
-	t.Run("nil pointer omits field", func(t *testing.T) {
-		data, err := json.Marshal(CheckHTTP{Name: "test", Encryption: nil})
+// TestChecks_EncryptionTriState verifies the *string semantics for
+// msp_encryption across every check struct that exposes the field:
+// nil pointer omits the field (server applies its default), pointer to ""
+// sends an explicit Off, and pointer to "SSL_TLS" sends explicit TLS-on.
+// Adding a new struct with msp_encryption? Add it to the table below.
+func TestChecks_EncryptionTriState(t *testing.T) {
+	type encCase struct {
+		name string
+		make func(enc *string) any
+	}
+	cases := []encCase{
+		{"http", func(e *string) any { return CheckHTTP{Name: "test", Encryption: e} }},
+		{"tcp", func(e *string) any { return CheckTCP{Name: "test", Encryption: e} }},
+		{"imap", func(e *string) any { return CheckIMAP{Name: "test", Encryption: e} }},
+		{"pop", func(e *string) any { return CheckPOP{Name: "test", Encryption: e} }},
+		{"smtp", func(e *string) any { return CheckSMTP{Name: "test", Encryption: e} }},
+		{"check", func(e *string) any { return Check{Name: "test", Encryption: e} }},
+	}
+
+	marshal := func(t *testing.T, v any) map[string]any {
+		t.Helper()
+		data, err := json.Marshal(v)
 		if err != nil {
 			t.Fatal(err)
 		}
-		m := unmarshalToMap(t, data)
-		if _, ok := m["msp_encryption"]; ok {
-			t.Error("expected 'msp_encryption' to be omitted when pointer is nil")
-		}
-	})
-	t.Run("pointer to empty string sends Off", func(t *testing.T) {
-		empty := ""
-		data, err := json.Marshal(CheckHTTP{Name: "test", Encryption: &empty})
-		if err != nil {
-			t.Fatal(err)
-		}
-		m := unmarshalToMap(t, data)
-		v, ok := m["msp_encryption"]
-		if !ok {
-			t.Fatal("expected 'msp_encryption' to be present when pointer is non-nil")
-		}
-		if v != "" {
-			t.Errorf("expected msp_encryption to be empty string, got %v", v)
-		}
-	})
-	t.Run("pointer to SSL_TLS sends TLS-on", func(t *testing.T) {
-		tls := "SSL_TLS"
-		data, err := json.Marshal(CheckHTTP{Name: "test", Encryption: &tls})
-		if err != nil {
-			t.Fatal(err)
-		}
-		m := unmarshalToMap(t, data)
-		if v := m["msp_encryption"]; v != "SSL_TLS" {
-			t.Errorf("expected msp_encryption=\"SSL_TLS\", got %v", v)
-		}
-	})
+		return unmarshalToMap(t, data)
+	}
+
+	for _, c := range cases {
+		t.Run(c.name+"/nil_pointer_omits_field", func(t *testing.T) {
+			m := marshal(t, c.make(nil))
+			if _, ok := m["msp_encryption"]; ok {
+				t.Errorf("expected 'msp_encryption' to be omitted when pointer is nil")
+			}
+		})
+		t.Run(c.name+"/empty_string_sends_off", func(t *testing.T) {
+			empty := ""
+			m := marshal(t, c.make(&empty))
+			v, ok := m["msp_encryption"]
+			if !ok {
+				t.Fatalf("expected 'msp_encryption' to be present when pointer is non-nil")
+			}
+			if v != "" {
+				t.Errorf("expected msp_encryption=\"\", got %v", v)
+			}
+		})
+		t.Run(c.name+"/SSL_TLS_sends_tls_on", func(t *testing.T) {
+			tls := "SSL_TLS"
+			m := marshal(t, c.make(&tls))
+			if v := m["msp_encryption"]; v != "SSL_TLS" {
+				t.Errorf("expected msp_encryption=\"SSL_TLS\", got %v", v)
+			}
+		})
+	}
 }
 
 func TestCheckHTTP_BoolPtrFalse(t *testing.T) {

--- a/pkg/upapi/ep_checks_pop.go
+++ b/pkg/upapi/ep_checks_pop.go
@@ -16,7 +16,7 @@ type CheckPOP struct {
 	Address                string          `json:"msp_address,omitempty"`
 	Port                   int64           `json:"msp_port,omitempty"`
 	ExpectString           string          `json:"msp_expect_string,omitempty"`
-	Encryption             string          `json:"msp_encryption,omitempty"`
+	Encryption             string          `json:"msp_encryption"`
 	Sensitivity            int64           `json:"msp_sensitivity,omitempty"`
 	NumRetries             int64           `json:"msp_num_retries,omitempty"`
 	UseIPVersion           string          `json:"msp_use_ip_version,omitempty"`

--- a/pkg/upapi/ep_checks_pop.go
+++ b/pkg/upapi/ep_checks_pop.go
@@ -16,7 +16,7 @@ type CheckPOP struct {
 	Address                string          `json:"msp_address,omitempty"`
 	Port                   int64           `json:"msp_port,omitempty"`
 	ExpectString           string          `json:"msp_expect_string,omitempty"`
-	Encryption             string          `json:"msp_encryption"`
+	Encryption             *string         `json:"msp_encryption,omitempty"`
 	Sensitivity            int64           `json:"msp_sensitivity,omitempty"`
 	NumRetries             int64           `json:"msp_num_retries,omitempty"`
 	UseIPVersion           string          `json:"msp_use_ip_version,omitempty"`

--- a/pkg/upapi/ep_checks_smtp.go
+++ b/pkg/upapi/ep_checks_smtp.go
@@ -18,7 +18,7 @@ type CheckSMTP struct {
 	Username               string          `json:"msp_username,omitempty"`
 	Password               string          `json:"msp_password,omitempty"`
 	ExpectString           string          `json:"msp_expect_string,omitempty"`
-	Encryption             string          `json:"msp_encryption,omitempty"`
+	Encryption             string          `json:"msp_encryption"`
 	Sensitivity            int64           `json:"msp_sensitivity,omitempty"`
 	NumRetries             int64           `json:"msp_num_retries,omitempty"`
 	UseIpVersion           string          `json:"msp_use_ip_version,omitempty"`

--- a/pkg/upapi/ep_checks_smtp.go
+++ b/pkg/upapi/ep_checks_smtp.go
@@ -18,7 +18,7 @@ type CheckSMTP struct {
 	Username               string          `json:"msp_username,omitempty"`
 	Password               string          `json:"msp_password,omitempty"`
 	ExpectString           string          `json:"msp_expect_string,omitempty"`
-	Encryption             string          `json:"msp_encryption"`
+	Encryption             *string         `json:"msp_encryption,omitempty"`
 	Sensitivity            int64           `json:"msp_sensitivity,omitempty"`
 	NumRetries             int64           `json:"msp_num_retries,omitempty"`
 	UseIpVersion           string          `json:"msp_use_ip_version,omitempty"`

--- a/pkg/upapi/ep_checks_tcp.go
+++ b/pkg/upapi/ep_checks_tcp.go
@@ -24,7 +24,7 @@ type CheckTCP struct {
 	ResponseTimeSLA        decimal.Decimal `json:"msp_response_time_sla,omitempty"`
 	Notes                  string          `json:"msp_notes,omitempty"`
 	IncludeInGlobalMetrics *bool           `json:"msp_include_in_global_metrics,omitempty"`
-	Encryption             string          `json:"msp_encryption,omitempty"`
+	Encryption             string          `json:"msp_encryption"`
 }
 
 type checksEndpointTCPImpl struct {

--- a/pkg/upapi/ep_checks_tcp.go
+++ b/pkg/upapi/ep_checks_tcp.go
@@ -24,7 +24,7 @@ type CheckTCP struct {
 	ResponseTimeSLA        decimal.Decimal `json:"msp_response_time_sla,omitempty"`
 	Notes                  string          `json:"msp_notes,omitempty"`
 	IncludeInGlobalMetrics *bool           `json:"msp_include_in_global_metrics,omitempty"`
-	Encryption             string          `json:"msp_encryption"`
+	Encryption             *string         `json:"msp_encryption,omitempty"`
 }
 
 type checksEndpointTCPImpl struct {

--- a/pkg/upapi/ep_statuspages.go
+++ b/pkg/upapi/ep_statuspages.go
@@ -14,7 +14,7 @@ type StatusPage struct {
 	PageType                  string `json:"page_type"`
 	Slug                      string `json:"slug"`
 	CNAME                     string `json:"cname"`
-	AllowSubscriptions        bool   `json:"allow_subscriptions"`
+	AllowSubscriptions        *bool  `json:"allow_subscriptions,omitempty"`
 	AllowSearchIndexing       bool   `json:"allow_search_indexing"`
 	AllowDrillDown            bool   `json:"allow_drill_down"`
 	AuthUsername              string `json:"auth_username"`

--- a/pkg/upapi/error.go
+++ b/pkg/upapi/error.go
@@ -12,16 +12,52 @@ import (
 
 var DecodeError = errors.New("error response decode error")
 
+// FieldErrors is the decoded `error_fields` payload. The server returns a
+// flat `field -> [msg, ...]` map for top-level field errors and a nested
+// `field -> {subfield: [msg, ...]}` object when the offending field is
+// itself a structured value (e.g. `cloudstatusconfig.service_name`).
+// UnmarshalJSON flattens nested objects into dotted-path keys so callers
+// always see a flat `map[string][]any`.
+type FieldErrors map[string][]any
+
+func (f *FieldErrors) UnmarshalJSON(data []byte) error {
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	out := make(FieldErrors)
+	flattenFieldErrors(out, "", raw)
+	*f = out
+	return nil
+}
+
+func flattenFieldErrors(dst FieldErrors, prefix string, src map[string]any) {
+	for k, v := range src {
+		key := k
+		if prefix != "" {
+			key = prefix + "." + k
+		}
+		switch t := v.(type) {
+		case []any:
+			dst[key] = append(dst[key], t...)
+		case map[string]any:
+			flattenFieldErrors(dst, key, t)
+		default:
+			dst[key] = append(dst[key], t)
+		}
+	}
+}
+
 type Error struct {
 	Response *http.Response
-	Code     string           `json:"error_code"`
-	Message  string           `json:"error_message"`
-	Fields   map[string][]any `json:"error_fields,omitempty"`
+	Code     string      `json:"error_code"`
+	Message  string      `json:"error_message"`
+	Fields   FieldErrors `json:"error_fields,omitempty"`
 }
 
 func NewError() *Error {
 	return &Error{
-		Fields: make(map[string][]any),
+		Fields: make(FieldErrors),
 	}
 }
 

--- a/pkg/upapi/error_test.go
+++ b/pkg/upapi/error_test.go
@@ -38,4 +38,39 @@ func TestErrorFromResponse(t *testing.T) {
 		err := ErrorFromResponse(&rs)
 		require.ErrorIs(t, err, DecodeError)
 	})
+	t.Run("flat field errors", func(t *testing.T) {
+		rs := http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body: io.NopCloser(strings.NewReader(`{
+				"messages": {
+					"error_code":    "VALIDATION_ERROR",
+					"error_message": "One or more fields failed validation.",
+					"error_fields":  {"locations": ["Please select at least one location."]}
+				}
+			}`)),
+			Request: &http.Request{URL: &url.URL{}},
+		}
+		err := NewError()
+		require.ErrorAs(t, ErrorFromResponse(&rs), &err)
+		require.Equal(t, []any{"Please select at least one location."}, err.Fields["locations"])
+	})
+	t.Run("nested field errors are flattened", func(t *testing.T) {
+		rs := http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body: io.NopCloser(strings.NewReader(`{
+				"messages": {
+					"error_code":    "VALIDATION_ERROR",
+					"error_message": "One or more fields failed validation.",
+					"error_fields":  {"cloudstatusconfig": {"service_name": ["Object with name=aws-ec2-us-east-1 does not exist."]}}
+				}
+			}`)),
+			Request: &http.Request{URL: &url.URL{}},
+		}
+		err := NewError()
+		require.ErrorAs(t, ErrorFromResponse(&rs), &err)
+		require.Equal(t,
+			[]any{"Object with name=aws-ec2-us-east-1 does not exist."},
+			err.Fields["cloudstatusconfig.service_name"],
+		)
+	})
 }

--- a/pkg/upapi/ptr.go
+++ b/pkg/upapi/ptr.go
@@ -5,3 +5,7 @@ package upapi
 func BoolPtr(v bool) *bool {
 	return &v
 }
+
+func StringPtr(v string) *string {
+	return &v
+}


### PR DESCRIPTION
SYS-1201

## Summary

Extends `CheckCloudStatusConfig` with the group-based monitoring fields and fixes three independent SDK bugs surfaced while wiring the new fields into the Terraform provider (PR `uptime-com/terraform-provider-uptime#230`).

## Changes

### `feat: extend CheckCloudStatusConfig with group-based monitoring fields` (`ba3e693`)

Adds `notify_only_on_down`, `group`, `monitoring_type`, `services`, `service_titles` to `CheckCloudStatusConfig` to match the OpenAPI spec. The legacy `service_name` field is preserved (server-side deprecated). Verified against the live API: the server parses and validates each new field in `cloudstatusconfig` POST payloads.

### `fix: decode nested error_fields and cloudstatus group response object` (`071c4d5`)

- **`Error.Fields`** changes from `map[string][]any` to a named `FieldErrors` type with a custom `UnmarshalJSON` that recursively flattens nested validation-error objects into dotted-path keys. The server returns `{"cloudstatusconfig": {"service_name": ["..."]}}` for nested fields; the old type blew up with *"cannot unmarshal object into Go struct field"* and masked the real error message.
- **`CheckCloudStatusConfig.Group`** changes from `*int64` to `*CloudStatusGroup`. The server accepts an integer ID on write but returns `{"id": N, "name": "..."}` on read, which made every cloudstatus response decode fail. The new type marshals to the bare int and unmarshals either an int or the nested object.
- **`upctl Bind`** gains an `Int64SliceVarP` case in the reflection-based flag binder. Without it, the CLI panicked at init time the moment `Services []int64` was added (this commit's responsibility).

### `fix: drop omitempty from msp_encryption so empty value reaches the server` (`bcacfaf`)

`MonitoringServiceEncryption` is a two-value enum: `""` (Off) and `"SSL_TLS"`. With `json:"msp_encryption,omitempty"` set on every check struct that has the field, sending `Encryption: ""` was silently stripped from the request payload and the server then applied its own `SSL_TLS` default. That made the *Off* state unreachable through this SDK and broke any caller (e.g. the Terraform provider's TCP encryption test) that tried to flip encryption off after creation. Removed `omitempty` from the field on `CheckHTTP`, `CheckTCP`, `CheckIMAP`, `CheckPOP`, `CheckSMTP`, and the unified `Check` response struct. Updated the JSON omission test and added a positive assertion that `""` is now sent on the wire.

## Test plan

- [x] `go test ./...` - green (`pkg/upapi` and `internal/upctl`).
- [x] New tests cover `FieldErrors` flattening, `CloudStatusGroup` int/object Unmarshal, and `msp_encryption` empty-string serialization.
- [x] Verified live against the US production API (`uptime.com`): nested validation errors decode cleanly, group-based cloudstatus checks create/read without errors, TCP encryption can be toggled to `""` and back to `SSL_TLS`.
- [x] Terraform provider PR pinned to `bcacfaf` and exercises all three fix paths in its acceptance suite.