### PR TITLE
feat: SYS-1246 cloudstatus lookup endpoints + component sorting_weight

### DIFF
--- a/internal/upctl/cli_checks_cloudstatus.go
+++ b/internal/upctl/cli_checks_cloudstatus.go
@@ -1,0 +1,91 @@
+package upctl
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/uptime-com/uptime-client-go/v2/pkg/upapi"
+)
+
+var checksCloudStatusGroupsCmd = &cobra.Command{
+	Use:   "cloudstatus-groups",
+	Short: "Discover cloud status providers usable in cloudstatus checks",
+}
+
+func init() {
+	checksCmd.AddCommand(checksCloudStatusGroupsCmd)
+}
+
+var (
+	checksCloudStatusGroupsListFlags = upapi.CloudStatusGroupListOptions{
+		Page:     1,
+		PageSize: 100,
+	}
+	checksCloudStatusGroupsListCmd = &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List cloud status provider groups",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return output(checksCloudStatusGroupsList(cmd.Context()))
+		},
+	}
+)
+
+func init() {
+	err := Bind(checksCloudStatusGroupsListCmd.Flags(), &checksCloudStatusGroupsListFlags)
+	if err != nil {
+		panic(err)
+	}
+	checksCloudStatusGroupsCmd.AddCommand(checksCloudStatusGroupsListCmd)
+}
+
+func checksCloudStatusGroupsList(ctx context.Context) ([]upapi.CloudStatusGroupListItem, error) {
+	result, err := api.Checks().ListCloudStatusGroups(ctx, checksCloudStatusGroupsListFlags)
+	if err != nil {
+		return nil, err
+	}
+	return result.Items, nil
+}
+
+var checksCloudStatusServicesCmd = &cobra.Command{
+	Use:   "cloudstatus-services",
+	Short: "Discover cloud status services usable in cloudstatus checks",
+}
+
+func init() {
+	checksCmd.AddCommand(checksCloudStatusServicesCmd)
+}
+
+var (
+	checksCloudStatusServicesListFlags = upapi.CloudStatusServiceListOptions{
+		Page:     1,
+		PageSize: 100,
+	}
+	checksCloudStatusServicesListCmd = &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List cloud status services (filter via --group=<id|name substring>)",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return output(checksCloudStatusServicesList(cmd.Context()))
+		},
+	}
+)
+
+func init() {
+	err := Bind(checksCloudStatusServicesListCmd.Flags(), &checksCloudStatusServicesListFlags)
+	if err != nil {
+		panic(err)
+	}
+	checksCloudStatusServicesCmd.AddCommand(checksCloudStatusServicesListCmd)
+}
+
+func checksCloudStatusServicesList(ctx context.Context) ([]upapi.CloudStatusService, error) {
+	result, err := api.Checks().ListCloudStatusServices(ctx, checksCloudStatusServicesListFlags)
+	if err != nil {
+		return nil, err
+	}
+	return result.Items, nil
+}

--- a/pkg/upapi/ep_checks.go
+++ b/pkg/upapi/ep_checks.go
@@ -287,6 +287,9 @@ type ChecksEndpoint interface {
 	CreateCloudStatus(context.Context, CheckCloudStatus) (*Check, error)
 	UpdateCloudStatus(context.Context, PrimaryKeyable, CheckCloudStatus) (*Check, error)
 
+	ListCloudStatusGroups(context.Context, CloudStatusGroupListOptions) (*ListResult[CloudStatusGroupListItem], error)
+	ListCloudStatusServices(context.Context, CloudStatusServiceListOptions) (*ListResult[CloudStatusService], error)
+
 	UpdateMaintenance(context.Context, PrimaryKeyable, CheckMaintenance) (*Check, error)
 
 	GetEscalations(context.Context, PrimaryKeyable) (*CheckEscalations, error)
@@ -395,6 +398,12 @@ func NewChecksEndpoint(cbd CBD) ChecksEndpoint {
 			EndpointCreator: NewEndpointCreator[CheckCloudStatus, CheckCreateUpdateResponse, Check](cbd, endpoint+"/add-cloudstatus"),
 			EndpointUpdater: NewEndpointUpdater[CheckCloudStatus, CheckCreateUpdateResponse, Check](cbd, endpoint),
 		},
+		checksEndpointCloudStatusGroupsImpl: checksEndpointCloudStatusGroupsImpl{
+			EndpointLister: NewEndpointLister[CloudStatusGroupListResponse, CloudStatusGroupListItem, CloudStatusGroupListOptions](cbd, endpoint+"/cloudstatus-groups"),
+		},
+		checksEndpointCloudStatusServicesImpl: checksEndpointCloudStatusServicesImpl{
+			EndpointLister: NewEndpointLister[CloudStatusServiceListResponse, CloudStatusService, CloudStatusServiceListOptions](cbd, endpoint+"/cloudstatus-services"),
+		},
 		checksEndpointMaintenanceImpl: checksEndpointMaintenanceImpl{
 			EndpointUpdater: NewEndpointUpdater[CheckMaintenance, CheckCreateUpdateResponse, Check](
 				&checksNestedEndpointCBD{CBD: cbd, EndpointSuffix: "maintenance/"}, endpoint,
@@ -441,6 +450,8 @@ type checksEndpointImpl struct {
 	checksStatsEndpointImpl
 	checksEndpointPageSpeedImpl
 	checksEndpointCloudStatusImpl
+	checksEndpointCloudStatusGroupsImpl
+	checksEndpointCloudStatusServicesImpl
 	checksEndpointMaintenanceImpl
 	checksEndpointLocationsImpl
 	checksEndpointEscalationsImpl

--- a/pkg/upapi/ep_checks_cloudstatus_groups.go
+++ b/pkg/upapi/ep_checks_cloudstatus_groups.go
@@ -1,0 +1,43 @@
+package upapi
+
+import "context"
+
+// CloudStatusGroupListItem is the read-only item shape returned by the
+// /checks/cloudstatus-groups/ lookup endpoint. It is intentionally separate
+// from CloudStatusGroup, which has a custom MarshalJSON that serializes as a
+// bare integer for the check-config write path - re-marshaling a list item
+// through that type would silently drop the Name.
+type CloudStatusGroupListItem struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+}
+
+type CloudStatusGroupListOptions struct {
+	Page     int64  `url:"page,omitempty"`
+	PageSize int64  `url:"page_size,omitempty"`
+	Search   string `url:"search,omitempty"`
+	Ordering string `url:"ordering,omitempty"`
+}
+
+type CloudStatusGroupListResponse struct {
+	Count   int64                      `json:"count,omitempty"`
+	Results []CloudStatusGroupListItem `json:"results,omitempty"`
+}
+
+func (r CloudStatusGroupListResponse) List() []CloudStatusGroupListItem {
+	return r.Results
+}
+
+func (r CloudStatusGroupListResponse) CountItems() int64 {
+	return r.Count
+}
+
+type checksEndpointCloudStatusGroupsImpl struct {
+	EndpointLister[CloudStatusGroupListResponse, CloudStatusGroupListItem, CloudStatusGroupListOptions]
+}
+
+func (c checksEndpointCloudStatusGroupsImpl) ListCloudStatusGroups(
+	ctx context.Context, opts CloudStatusGroupListOptions,
+) (*ListResult[CloudStatusGroupListItem], error) {
+	return c.List(ctx, opts)
+}

--- a/pkg/upapi/ep_checks_cloudstatus_groups_test.go
+++ b/pkg/upapi/ep_checks_cloudstatus_groups_test.go
@@ -1,0 +1,63 @@
+package upapi
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChecksEndpointListCloudStatusGroups(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/api/v1/checks/cloudstatus-groups/", r.URL.Path)
+		require.Equal(t, "aws", r.URL.Query().Get("search"))
+		_, _ = io.WriteString(w, `{
+			"count": 2,
+			"results": [
+				{"id": 1, "name": "Amazon Web Services"},
+				{"id": 2, "name": "AWS Marketplace"}
+			]
+		}`)
+	}))
+
+	cbd, err := WithBaseURL(srv.URL + "/api/v1/")(testCBD)
+	require.NoError(t, err)
+
+	ep := NewChecksEndpoint(cbd)
+
+	result, err := ep.ListCloudStatusGroups(ctx, CloudStatusGroupListOptions{Search: "aws"})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), result.TotalCount)
+	require.Len(t, result.Items, 2)
+	require.Equal(t, int64(1), result.Items[0].ID)
+	require.Equal(t, "Amazon Web Services", result.Items[0].Name)
+	require.Equal(t, int64(2), result.Items[1].ID)
+}
+
+func TestChecksEndpointListCloudStatusGroupsEmpty(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/api/v1/checks/cloudstatus-groups/", r.URL.Path)
+		_, _ = io.WriteString(w, `{"count": 0, "results": []}`)
+	}))
+
+	cbd, err := WithBaseURL(srv.URL + "/api/v1/")(testCBD)
+	require.NoError(t, err)
+
+	ep := NewChecksEndpoint(cbd)
+
+	result, err := ep.ListCloudStatusGroups(ctx, CloudStatusGroupListOptions{})
+	require.NoError(t, err)
+	require.Equal(t, int64(0), result.TotalCount)
+	require.Empty(t, result.Items)
+}

--- a/pkg/upapi/ep_checks_cloudstatus_services.go
+++ b/pkg/upapi/ep_checks_cloudstatus_services.go
@@ -1,0 +1,43 @@
+package upapi
+
+import "context"
+
+type CloudStatusService struct {
+	ID       int64  `json:"id"`
+	Name     string `json:"name"`
+	Title    string `json:"title,omitempty"`
+	SubTitle string `json:"sub_title,omitempty"`
+	GroupID  int64  `json:"group_id"`
+	Group    string `json:"group,omitempty"`
+}
+
+type CloudStatusServiceListOptions struct {
+	Page     int64  `url:"page,omitempty"`
+	PageSize int64  `url:"page_size,omitempty"`
+	Group    string `url:"group,omitempty"`
+	Search   string `url:"search,omitempty"`
+	Ordering string `url:"ordering,omitempty"`
+}
+
+type CloudStatusServiceListResponse struct {
+	Count   int64                `json:"count,omitempty"`
+	Results []CloudStatusService `json:"results,omitempty"`
+}
+
+func (r CloudStatusServiceListResponse) List() []CloudStatusService {
+	return r.Results
+}
+
+func (r CloudStatusServiceListResponse) CountItems() int64 {
+	return r.Count
+}
+
+type checksEndpointCloudStatusServicesImpl struct {
+	EndpointLister[CloudStatusServiceListResponse, CloudStatusService, CloudStatusServiceListOptions]
+}
+
+func (c checksEndpointCloudStatusServicesImpl) ListCloudStatusServices(
+	ctx context.Context, opts CloudStatusServiceListOptions,
+) (*ListResult[CloudStatusService], error) {
+	return c.List(ctx, opts)
+}

--- a/pkg/upapi/ep_checks_cloudstatus_services_test.go
+++ b/pkg/upapi/ep_checks_cloudstatus_services_test.go
@@ -1,0 +1,81 @@
+package upapi
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChecksEndpointListCloudStatusServices(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/api/v1/checks/cloudstatus-services/", r.URL.Path)
+		require.Equal(t, "1", r.URL.Query().Get("group"))
+		_, _ = io.WriteString(w, `{
+			"count": 2,
+			"results": [
+				{
+					"id": 10,
+					"name": "ec2-us-east-1",
+					"title": "EC2",
+					"sub_title": "US East (N. Virginia)",
+					"group_id": 1,
+					"group": "Amazon Web Services"
+				},
+				{
+					"id": 11,
+					"name": "s3-us-east-1",
+					"title": "S3",
+					"sub_title": "US East (N. Virginia)",
+					"group_id": 1,
+					"group": "Amazon Web Services"
+				}
+			]
+		}`)
+	}))
+
+	cbd, err := WithBaseURL(srv.URL + "/api/v1/")(testCBD)
+	require.NoError(t, err)
+
+	ep := NewChecksEndpoint(cbd)
+
+	result, err := ep.ListCloudStatusServices(ctx, CloudStatusServiceListOptions{Group: "1"})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), result.TotalCount)
+	require.Len(t, result.Items, 2)
+	require.Equal(t, int64(10), result.Items[0].ID)
+	require.Equal(t, "ec2-us-east-1", result.Items[0].Name)
+	require.Equal(t, "EC2", result.Items[0].Title)
+	require.Equal(t, "US East (N. Virginia)", result.Items[0].SubTitle)
+	require.Equal(t, int64(1), result.Items[0].GroupID)
+	require.Equal(t, "Amazon Web Services", result.Items[0].Group)
+}
+
+func TestChecksEndpointListCloudStatusServicesFilterByGroupName(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/api/v1/checks/cloudstatus-services/", r.URL.Path)
+		require.Equal(t, "Amazon", r.URL.Query().Get("group"))
+		_, _ = io.WriteString(w, `{"count": 0, "results": []}`)
+	}))
+
+	cbd, err := WithBaseURL(srv.URL + "/api/v1/")(testCBD)
+	require.NoError(t, err)
+
+	ep := NewChecksEndpoint(cbd)
+
+	result, err := ep.ListCloudStatusServices(ctx, CloudStatusServiceListOptions{Group: "Amazon"})
+	require.NoError(t, err)
+	require.Equal(t, int64(0), result.TotalCount)
+	require.Empty(t, result.Items)
+}

--- a/pkg/upapi/ep_statuspages_components.go
+++ b/pkg/upapi/ep_statuspages_components.go
@@ -15,6 +15,7 @@ type StatusPageComponent struct {
 	Status         string `json:"status,omitempty"`
 	AutoStatusDown string `json:"auto_status_down,omitempty"`
 	AutoStatusUp   string `json:"auto_status_up,omitempty"`
+	SortingWeight  *int64 `json:"sorting_weight,omitempty"`
 }
 
 func (s StatusPageComponent) PrimaryKey() PrimaryKey {


### PR DESCRIPTION
Add two list endpoints on ChecksEndpoint for discovering Cloud Status provider groups and services:

  ListCloudStatusGroups(opts) -> /api/v1/checks/cloudstatus-groups/
  ListCloudStatusServices(opts) -> /api/v1/checks/cloudstatus-services/

Both endpoints already exist server-side; this exposes them in the Go client so the Terraform provider can offer corresponding data sources. Groups support ?search=; services support ?group=<id|name substring> and ?search=.

CloudStatusGroupListItem is intentionally a separate type from CloudStatusGroup (whose custom MarshalJSON serializes as a bare integer for the check-config write path). Re-marshaling a list item through that type would silently drop the Name.

Also add SortingWeight *int64 to StatusPageComponent for SYS-1246 part two. The server already stores this field; this commit only adds it to the client struct so the Terraform provider can manage it as a regular component attribute.